### PR TITLE
upgrade the image to 2017

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,18 @@
-FROM ddidier/ndd-docker-sphinx:latest
+FROM bitnami/minideb:stretch
 
-MAINTAINER Helge Sychla helge.sychla@travelping.com
-
-RUN sudo apt-get update -qq && sudo apt-get -y install texlive-latex-base texlive-latex-recommended texlive-font-utils texlive-fonts-extra texlive-fonts-recommended texlive-latex-extra texlive-latex-recommended
-
-CMD bash
+RUN  install_packages \
+        gettext-base \
+        python-pip \
+        python-setuptools \
+        make \
+        git \
+        graphviz \
+        latexmk \
+        plantuml \
+        sphinx-common \
+        texlive-fonts-recommended \
+        texlive-latex-base \
+        texlive-latex-extra \
+        texlive-latex-recommended && \
+     pip install --no-cache-dir \
+        sphinxcontrib-plantuml

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+IMAGE_NAME=tpdock/sphinxdoc:latest
+
+build: Dockerfile
+	docker build -t $(IMAGE_NAME) .
+
+push:
+	docker push $(IMAGE_NAME)
+
+run:
+	docker run -it --rm $(IMAGE_NAME)
+

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,0 @@
-docker build --no-cache=true --rm=true -t tpdock/sphinxdoc:latest .

--- a/push.sh
+++ b/push.sh
@@ -1,1 +1,0 @@
-docker push tpdock/sphinxdoc:latest

--- a/run.sh
+++ b/run.sh
@@ -1,1 +1,0 @@
-docker run -it --rm tpdock/sphinxdoc:latest


### PR DESCRIPTION
* base-image is bitnami/minideb:stretch
* the overwall image size shrinks from 2.something GB down to 850MB
* plantuml is used from the debian repos itself

the Makefile is more natural for building things, it replaces
all the *.sh scripts.