### PR TITLE
Update Dockerfile to contain epstopdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN  install_packages \
         graphviz \
         latexmk \
         plantuml \
+        texlive-font-utils \
         sphinx-common \
         texlive-fonts-recommended \
         texlive-latex-base \


### PR DESCRIPTION
this enables rendering of eps files directly in the pdf
the uml package of sphinx heavily relies on this to render
in good quality

sources:
see "Configuration/eps" in the [sphinx expansion for plantuml](https://pypi.python.org/pypi/sphinxcontrib-plantuml)
see [this short hint](https://www.randomhacks.co.uk/how-to-install-epstopdf-on-ubuntu/) on which package actually contains epstopdf